### PR TITLE
add script/bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 output
 .env
 node_modules
+whisper.cpp

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tell a story and get a live feed of images
 ```
 git clone https://github.com/zeke/livestory
 cd livestory
-npm install
+script/bootstrap
 ```
 
 ## Usage

--- a/listen.sh
+++ b/listen.sh
@@ -1,2 +1,7 @@
-cd /Users/charlieholtz/workspace/dev/whisper.cpp
+if [ ! -d "whisper.cpp" ]; then
+  echo "whisper.cpp not found. To download and build it, run script/bootstrap"
+  exit
+fi
+
+cd whisper.cpp
 ./stream -m ./models/ggml-base.en.bin -t 8 --step 500 --length 5000

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# set up local whisper.cpp and download model
+git clone https://github.com/ggerganov/whisper.cpp
+cd whisper.cpp
+bash ./models/download-ggml-model.sh base.en
+make stream
+
+# install npm deps
+cd ..
+npm install


### PR DESCRIPTION
This PR adds a `script/bootstrap` command for getting the project set up. It takes care of this stuff:

- download whisper.cpp
- download the whisper model
- build whisper's streaming CLI binary
- npm install

cc @cbh123 